### PR TITLE
Add names for status IDs, support for protocol versions which include a substatus ID

### DIFF
--- a/davinciprinter/StatusTranslation.go
+++ b/davinciprinter/StatusTranslation.go
@@ -22,75 +22,61 @@ package davinciprinter
 func GetStatusText(code int) string {
 	switch code {
 	case 0:
-
 		return "Initializing..."
 
 	case 1:
-
 		return "Heating"
 
 	case 2:
-
 		return "Printing"
 
 	case 3:
-
 		return "Calibrating"
 
 	case 4:
-
 		return "Calibrating Done"
 
 	case 5:
-
 		return "Cooling Finished"
 
 	case 6:
-
 		return "Cooling Finished."
 
 	case 7:
-
 		return "Print Process Ending"
 
 	case 8:
-
 		return "Print Process Ending."
 
 	case 9:
-
 		return "Print Job Finished"
 
 	case 10:
-
 		return "Ready"
 
 	case 11:
 		return "Preparing Print"
 
 	case 12:
-
 		return "Print Stopped"
 
 	case 13:
-
 		return "Loading Filament"
 
 	case 14:
-
 		return "Unloading filament"
 
 	case 15:
-
 		return "Auto Calibration"
 
 	case 16:
-
 		return "Job Mode"
 
 	case 17:
-
 		return "Print Error"
+
+	case 30:
+		return "Printer Busy"
 
 	case 9601:
 		return "Print Job Paused"
@@ -98,6 +84,105 @@ func GetStatusText(code int) string {
 	case 9602:
 		return "Print Job Cancelled"
 
+	case 9500:
+		return "Initializing..."
+
+	case 9501:
+		return "Heating"
+
+	case 9502:
+		return "Printing"
+
+	case 9503:
+		return "Calibrating"
+
+	case 9504:
+		return "Calibrating Done"
+
+	case 9505:
+		return "Printing In Progress"
+
+	case 9506:
+		return "Cooling Finished"
+
+	case 9507:
+		return "Cooling Finished."
+
+	case 9508:
+		return "Print Process Ending."
+
+	case 9509:
+		return "Print Process Ending."
+
+	case 9510:
+		return "Print Job Finished"
+
+	case 9511:
+		return "Ready"
+
+	case 9512:
+		return "Print Stopped"
+
+	case 9513:
+		return "Loading Filament."
+
+	case 9514:
+		return "Unloading filament."
+
+	case 9515:
+		return "Auto Calibration"
+
+	case 9516:
+		return "Job Mode."
+
+	case 9517:
+		return "Print Error."
+
+	case 9520:
+		return "Print file check"
+
+	case 9530:
+		return "Loading Filament.."
+
+	case 9531:
+		return "Unloading Filament.."
+
+	case 9532:
+		return "Job Mode.."
+
+	case 9533:
+		return "Print Error.."
+
+	case 9534:
+		return "Homing"
+
+	case 9535:
+		return "Calibrating."
+
+	case 9536:
+		return "Cleaning Nozzle"
+
+	case 9537:
+		return "Get SD File"
+
+	case 9538:
+		return "Print SD File"
+
+	case 9539:
+		return "Print Engrave Place Object"
+
+	case 9540:
+		return "Adjusting Z-Offset"
+
+	case 9700:
+		return "Busy"
+
+	case 9800:
+		return "Scanner Idle"
+
+	case 9801:
+		return "Scanner Running"
 	}
-	return ""
+
+	return "<Unknown>"
 }

--- a/printerWebApi.go
+++ b/printerWebApi.go
@@ -73,7 +73,9 @@ func getStatusFromMap(values map[string]string) (*StatusQuery, error) {
 		if len(parts) < 2 {
 			return nil, errors.New("unexpected format")
 		}
+
 		status.Temperature, err = strconv.Atoi(parts[1])
+
 		if err != nil {
 			log.Println(err)
 			return nil, err
@@ -88,16 +90,21 @@ func getStatusFromMap(values map[string]string) (*StatusQuery, error) {
 		}
 
 		status.PrintProgress, err = strconv.Atoi(parts[0])
+
 		if err != nil {
 			log.Println(err)
 			return nil, err
 		}
+
 		status.ElapsedMinutes, err = strconv.Atoi(parts[1])
+
 		if err != nil {
 			log.Println(err)
 			return nil, err
 		}
+
 		status.EstmatedMinutes, err = strconv.Atoi(parts[2])
+
 		if err != nil {
 			log.Println(err)
 			return nil, err
@@ -105,11 +112,19 @@ func getStatusFromMap(values map[string]string) (*StatusQuery, error) {
 	}
 
 	if val, exists := values[PrinterStatusId]; exists {
+		if strings.Contains(val, ",") {
+			// Handle presence of substatus ID
+			fields := strings.Split(val, ",")
+			val = fields[0]
+		}
+
 		statusCode, err := strconv.Atoi(val)
+
 		if err != nil {
 			log.Println(err)
 			return nil, err
 		}
+
 		status.PrinterStatus = davinciprinter.GetStatusText(statusCode)
 		fmt.Println(statusCode)
 	}
@@ -137,6 +152,7 @@ func getStatusFromMap(values map[string]string) (*StatusQuery, error) {
 		}
 
 		status.Filament.Remaining, err = strconv.Atoi(parts[1])
+
 		if err != nil {
 			log.Println(err)
 			return nil, err
@@ -151,6 +167,7 @@ func getStatusFromMap(values map[string]string) (*StatusQuery, error) {
 	if val, exists := values[ProductSerialId]; exists {
 		status.PrinterInfo.Serial = val
 	}
+
 	return &status, nil
 }
 


### PR DESCRIPTION
I made some changes to get this working with my mini w+ (dv1MW0C000):

* Add names for some status IDs
* Change name for unrecognised status IDs from "" to "<Unknown>"
* Add support for versions of the protocol which include a substatus ID


There are also some minor style changes; feel free to revert these:

* Remove unnecessary newlines in davinciprinter/StatusTranslation.go:GetStatusText()
* Add newlines between blocks in printerWebApi.go to ensure consistency